### PR TITLE
Disable tests for the kFreeBSD backend of Mirage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ J ?= 2
 PREFIX ?= /usr/local
 NAME=dyntype
 
+ifeq "$(findstring $(MIRAGE_OS),kfreebsd)" ""
+TESTS ?= --enable-tests
+endif
+
 setup.bin: setup.ml
 	ocamlopt.opt -o $@ $< || ocamlopt -o $@ $< || ocamlc -o $@ $<
 	rm -f setup.cmx setup.cmi setup.o setup.cmo
 
 setup.data: setup.bin
-	./setup.bin -configure --prefix $(PREFIX) --enable-tests
+	./setup.bin -configure --prefix $(PREFIX) $(TESTS)
 
 build: setup.data setup.bin
 	./setup.bin -build -j $(J)


### PR DESCRIPTION
I had to conditionally disable the bundled tests as the corresponding binaries cannot be built properly with the Mirage/kFreeBSD cross-compiler.  This change should not affect other cases.
