### PR TITLE
Add support for disabling generation of executables.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.9.1 (Oct 2012):
 * Switch build system to OASIS (Paolo Donadeo)
+* Make building and running tests optional
 
 0.9.0 (Oct 2012):
 * Support (and require) type_conv-108.07.00+

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ J ?= 2
 PREFIX ?= /usr/local
 NAME=dyntype
 
+ifeq "$(NO_EXECUTABLES)" ""
+TESTS ?= --enable-tests
+endif
+
 setup.bin: setup.ml
 	ocamlopt.opt -o $@ $< || ocamlopt -o $@ $< || ocamlc -o $@ $<
 	rm -f setup.cmx setup.cmi setup.o setup.cmo
 
 setup.data: setup.bin
-	./setup.bin -configure --prefix $(PREFIX) --enable-tests
+	./setup.bin -configure --prefix $(PREFIX) $(TESTS)
 
 build: setup.data setup.bin
 	./setup.bin -build -j $(J)


### PR DESCRIPTION
This is the reworked version of my previous pull request.  It features the previously discussed check for the presence of the `NO_EXECUTABLES` (environment) variables that would allow disabling generation of ELF binaries and would not be specific to the Mirage/kFreeBSD cross-compiler.
